### PR TITLE
README: use nixosModules.default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ you'll have to manually enable the service for each user (see below).
   outputs = { self, nixpkgs, vscode-server }: {
     nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
       modules = [
-        vscode-server.nixosModule
+        vscode-server.nixosModules.default
         ({ config, pkgs, ... }: {
           services.vscode-server.enable = true;
         })


### PR DESCRIPTION
According to 7d9f9a789e51ff22d85e48009bf75593645d8de1, the old `nixosModule` attribute is "deprecrated, but perhaps still in use". However, the README still recommends it. I'm not entirely sure, but if I understand correctly, it must be replaced with `nixosModules.default`.