### PR TITLE
Support for new dir structure of vscode server

### DIFF
--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -136,6 +136,10 @@
         local bin=$1
         bin="''${bin//[$' \t\n\r']}"
         if [[ $bins_dir == "${installPath}/cli/servers" ]]; then
+          if [[ $bin == *".staging" ]]; then
+            bin=''${bin%%.staging}
+            mv "$bins_dir/''${bin}.staging" "$bins_dir/''${bin}"
+          fi
           local actual_dir=$bins_dir/$bin/server
         else
           local actual_dir=$bins_dir/$bin

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -21,7 +21,7 @@
   enableFHS ? false,
   nodejsPackage ? null,
   extraRuntimeDependencies ? [ ],
-  installPath ? "~/.vscode-server",
+  installPath ? "$HOME/.vscode-server",
   postPatch ? "",
 }: let
   inherit (lib) makeBinPath makeLibraryPath optionalString;
@@ -71,8 +71,8 @@
     name = "patchelf-vscode-server";
     runtimeInputs = [ coreutils findutils patchelf ];
     text = ''
-      bin=$1
-      bin_dir=${installPath}/bin/$bin
+      bin=$(basename "$(dirname "$1")")
+      bin_dir=$1
       patched_file=${installPath}/.$bin.patched
       orig_node=${installPath}/.$bin.node
 
@@ -126,12 +126,20 @@
     name = "auto-fix-vscode-server";
     runtimeInputs = [ coreutils findutils inotify-tools ];
     text = ''
-      bins_dir=${installPath}/bin
+      if [[ -e ${installPath}/cli/servers ]]; then
+        bins_dir=${installPath}/cli/servers
+      else
+        bins_dir=${installPath}/bin
+      fi
 
       patch_bin () {
         local bin=$1
-        bin=''${bin:0:40}
-        local actual_dir=$bins_dir/$1
+        bin="''${bin//[$' \t\n\r']}"
+        if [[ $bins_dir == "${installPath}/cli/servers" ]]; then
+          local actual_dir=$bins_dir/$bin/server
+        else
+          local actual_dir=$bins_dir/$bin
+        fi
         local patched_file=${installPath}/.$bin.patched
 
         if [[ -e $patched_file ]]; then
@@ -159,7 +167,7 @@
 
         # We leave the rest up to the Bash script
         # to keep having to deal with 'sh' compatibility to a minimum.
-        ${patchELFScript}/bin/patchelf-vscode-server '$bin'
+        ${patchELFScript}/bin/patchelf-vscode-server '$actual_dir'
 
         # Let Node.js take over as if this script never existed.
         exec '$orig_node' "\$@"

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -138,6 +138,9 @@
         if [[ $bins_dir == "${installPath}/cli/servers" ]]; then
           if [[ $bin == *".staging" ]]; then
             bin=''${bin%%.staging}
+            if [[ -e $bins_dir/''${bin} ]]; then
+              rm -rf "$bins_dir/''${bin:?}"
+            fi
             mv "$bins_dir/''${bin}.staging" "$bins_dir/''${bin}"
           fi
           local actual_dir=$bins_dir/$bin/server


### PR DESCRIPTION
I was using Visual Studio Code Insiders. I had the problem reported in #67.
I did a little miscellaneous hack for myself and sent a PR.

I'm covering two problems.

## Problem 1

The directory in which the actual vscode server is located has been changed.

Before: `~/.vscode-server/bin/<release_hash>/`
After: `~/.vscode-server/cli/servers/<release_hash>/server/`

My hack checks if the changed directory exists and replaces `bins_dir'.

## Problem 2

The insider binary that has been in use since September adds a behavior that when vscode-server is deployed to a remote host, it will expand the remote host as a staging directory before checking its operation. This staging directory will be appended to the release_hash with the string *.staging*.
As you know, vscode-server cannot use the built-in node until the patch is applied. Therefore, this staging phase of vscode will always fail.

To fix this, we have added an `if` statement to change the directory name to one without the .staging string by the `mv` command if the directory ends in .staging