### PR TITLE
Support more recent VSCode Server versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The installation path for VS Code server is configurable and the default can dif
 
 ```nix
 {
-  services.vscode-server.installPath = "~/.vscode-server-oss";
+  services.vscode-server.installPath = "$HOME/.vscode-server-oss";
 }
 ```
 

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -34,8 +34,8 @@ moduleConfig: {
 
     installPath = mkOption {
       type = str;
-      default = "~/.vscode-server";
-      example = "~/.vscode-server-oss";
+      default = "$HOME/.vscode-server";
+      example = "$HOME/.vscode-server-oss";
       description = ''
         The install path.
       '';

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -134,6 +134,21 @@
           return 0
         fi
 
+        # Backwards compatibility with previous versions of nixos-vscode-server.
+        local old_patched_file
+        old_patched_file="$(basename "$actual_dir")"
+        if [[ $old_patched_file == "server" ]]; then
+          old_patched_file="$(basename "$(dirname "$actual_dir")")"
+          old_patched_file="${installPath}/.''${old_patched_file%%.*}.patched"
+        else
+          old_patched_file="${installPath}/.''${old_patched_file%%-*}.patched"
+        fi
+        if [[ -e $old_patched_file ]]; then
+          echo "Migrating old nixos-vscode-server patch marker file to new location in $actual_dir." >&2
+          cp "$old_patched_file" "$patched_file"
+          return 0
+        fi
+
         echo "Patching Node.js of VS Code server installation in $actual_dir..." >&2
 
         mv "$actual_dir/node" "$actual_dir/node.patched"

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -21,7 +21,7 @@
   enableFHS ? false,
   nodejsPackage ? null,
   extraRuntimeDependencies ? [ ],
-  installPath ? "~/.vscode-server",
+  installPath ? "$HOME/.vscode-server",
   postPatch ? "",
 }: let
   inherit (lib) makeBinPath makeLibraryPath optionalString;


### PR DESCRIPTION
Following this message:
https://github.com/nix-community/nixos-vscode-server/issues/67#issuecomment-1991011917

It took me some time to actually understand what was going on and propose this implementation - it's cleaner than that of #68 and seems more stable.

Notably this change the directory structure a bit, leaving patched files in their respective directories, which feels simpler and cleaner because I don't need to construct global filenames whose construction method depends on the VSCode version. (I'm using `\$(dirname "\$0")` in the intermediate script that replaces the node binary so that it keeps working after the directory is moved).

I've tested that this works:
- On old VSCode remote versions
- On new VSCode remote versions
- Migrating from previous directory structure to new directory structure (so updating the flake won't break existing users)