### PR TITLE
Add option to enable the service for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ you'll have to manually enable the service for each user (see below).
 
 #### Enable the service
 
+##### Automatically for all users
+
+Instead of just
+```nix
+{ services.vscode-server.enable = true; }
+```
+
+use:
+```nix
+{
+  services.vscode-server = {
+    enable = true;
+    enableForAllUsers = true;
+  };
+}
+```
+
+This will use `tmpfiles` to setup the permanent symlink described below for each regular user.
+
+##### Manually for each user
+
 And then enable them for the relevant users:
 
 ```bash
@@ -79,6 +100,8 @@ ln -sfT /run/current-system/etc/systemd/user/auto-fix-vscode-server.service ~/.c
 
 ### Home Manager
 
+#### Install as a tarball
+
 Put this code into your [home-manager](https://github.com/nix-community/home-manager) configuration i.e. in `~/.config/nixpkgs/home.nix`:
 
 ```nix
@@ -88,6 +111,25 @@ Put this code into your [home-manager](https://github.com/nix-community/home-man
   ];
 
   services.vscode-server.enable = true;
+}
+```
+
+#### Install as a flake
+
+```nix
+{
+  inputs.vscode-server.url = "github:nix-community/nixos-vscode-server";
+
+  outputs = { self, vscode-server, home-manager }: {
+    homeConfigurations.yourhostname = home-manager.lib.homeManagerConfiguration {
+      modules = [
+        vscode-server.homeModules.default
+        ({ config, pkgs, ... }: {
+          services.vscode-server.enable = true;
+        })
+      ];
+    };
+  };
 }
 ```
 

--- a/modules/vscode-server/default.nix
+++ b/modules/vscode-server/default.nix
@@ -1,10 +1,57 @@
-import ./module.nix ({
-  name,
-  description,
-  serviceConfig,
-}: {
-  systemd.user.services.${name} = {
-    inherit description serviceConfig;
-    wantedBy = [ "default.target" ];
-  };
-})
+import ./module.nix (
+  { name
+  , description
+  , serviceConfig
+  , lib
+  , config
+  , cfg
+  }: lib.mkMerge [
+    {
+      systemd.user.services.${name} = {
+        inherit description serviceConfig;
+        wantedBy = [ "default.target" ];
+      };
+    }
+    (lib.mkIf cfg.enableForAllUsers {
+      systemd.tmpfiles.settings =
+        let
+          forEachUser = ({ path, file }: lib.attrsets.mapAttrs'
+            (username: userOptions:
+              {
+                # Create the directory so that it has the appropriate permissions if it doesn't already exist
+                # Otherwise the directive below creating the symlink would have that owned by root
+                name = "${userOptions.home}/${path}";
+                value = file username;
+              })
+            (lib.attrsets.filterAttrs (username: userOptions: userOptions.isNormalUser) config.users.users));
+          homeDirectory = (path: forEachUser {
+            inherit path;
+            file = (username: {
+              "d" = {
+                user = username;
+                group = "users";
+                mode = "0755";
+              };
+            });
+          });
+        in
+        {
+          # We need to create each of the folders before the next file otherwise parents get owned by root
+          "80-setup-config-folder-for-all-users" = homeDirectory ".config";
+          "81-setup-systemd-folder-for-all-users" = homeDirectory ".config/systemd";
+          "82-setup-systemd-user-folder-for-all-users" = homeDirectory ".config/systemd/user";
+          "83-enable-auto-fix-vscode-server-service-for-all-users" = forEachUser {
+            path = ".config/systemd/user/auto-fix-vscode-server.service";
+            file = (username: {
+              "L+" = {
+                user = username;
+                group = "users";
+                # This path is made available by `services.vscode-server.enable = true;`
+                argument = "/run/current-system/etc/systemd/user/auto-fix-vscode-server.service";
+              };
+            });
+          };
+        };
+    })
+  ]
+)

--- a/modules/vscode-server/home.nix
+++ b/modules/vscode-server/home.nix
@@ -1,17 +1,26 @@
-import ./module.nix ({
-  name,
-  description,
-  serviceConfig,
-}: {
-  systemd.user.services.${name} = {
-    Unit = {
-      Description = description;
+import ./module.nix (
+  { name
+  , description
+  , serviceConfig
+  , cfg
+  , ...
+  }:
+  {
+    systemd.user.services.${name} = {
+      Unit = {
+        Description = description;
+      };
+
+      Service = serviceConfig;
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
 
-    Service = serviceConfig;
-
-    Install = {
-      WantedBy = [ "default.target" ];
-    };
-  };
-})
+    assertions = [{
+      assertion = !cfg.enableForAllUsers;
+      message = "enableForAllUsers=true doesn't make sense when using nixos-vscode-server as a home-manager module";
+    }];
+  }
+)


### PR DESCRIPTION
Resolves #69
Resolves #65

**What it does:**
- When the `services.vscode-server.enableForAllUsers = true` is specified and using `nixos-vscode-server` as a NixOS module, uses `tmpfiles` to setup the appropriate symlinks to enable the service for all regular users
- Adds relevant instructions to the README
- Also adds instructions to the README to add instructions about how to use `nixos-vscode-server` as a home-manager module in combination with flakes