### PR TITLE
Support multiple installPath entries

### DIFF
--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -33,11 +33,11 @@ moduleConfig: {
     };
 
     installPath = mkOption {
-      type = str;
-      default = "$HOME/.vscode-server";
-      example = "$HOME/.vscode-server-oss";
+      type = listOf str;
+      default = [ "$HOME/.vscode-server" ];
+      example = [ "$HOME/.vscode-server-oss" ];
       description = ''
-        The install path.
+        A list of install paths.
       '';
     };
 


### PR DESCRIPTION
To support both VSCode, the Cursor IDE, and maybe something else, I've changed the implementation of the scripts a bit to support multiple values for the `installPath`.