### PR TITLE
Support monitor multiple install path simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,25 @@ This same list is also used to determine the `RPATH` when automatically patching
 ```
 
 ### `installPath`
-The installation path for VS Code server is configurable and the default can differ for alternative builds (e.g. oss and insider), so this option allows you to configure which installation path should be monitered and automatically fixed. If you have multiple installations, you can specify them as an array.
+The installation path for VS Code server is configurable. You can specify either a single path as a string or multiple paths as a list. If you have multiple installations (e.g., stable, OSS, and insider builds), you can specify all of them to be monitored and automatically fixed.
 
 ```nix
+# Single path (string)
 {
-  services.vscode-server.installPath = [ "$HOME/.vscode-server" "$HOME/.vscode-server-oss" ];
+  services.vscode-server.installPath = "$HOME/.vscode-server";
+}
+
+# Multiple paths (list)
+{
+  services.vscode-server.installPath = [
+    "$HOME/.vscode-server"
+    "$HOME/.vscode-server-oss"
+    "$HOME/.vscode-server-insiders"
+  ];
 }
 ```
+
+String values are automatically coerced to a single-element list for backwards compatibility.
 
 ### `postPatch`
 The goal of this project is to make VS Code server work with NixOS, anything more is outside of the scope of the project, but if you want additional things to be done, you can use this hook to run a shell script after the patching is done.

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ This same list is also used to determine the `RPATH` when automatically patching
 ```
 
 ### `installPath`
-The installation path for VS Code server is configurable and the default can differ for alternative builds (e.g. oss and insider), so this option allows you to configure which installation path should be monitered and automatically fixed.
+The installation path for VS Code server is configurable and the default can differ for alternative builds (e.g. oss and insider), so this option allows you to configure which installation path should be monitered and automatically fixed. If you have multiple installations, you can specify them as an array.
 
 ```nix
 {
-  services.vscode-server.installPath = "$HOME/.vscode-server-oss";
+  services.vscode-server.installPath = [ "$HOME/.vscode-server" "$HOME/.vscode-server-oss" ];
 }
 ```
 

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -33,11 +33,13 @@ moduleConfig: {
     };
 
     installPath = mkOption {
-      type = listOf str;
+      type = lib.types.coercedTo str (x: [x]) (listOf str);
       default = [ "$HOME/.vscode-server" ];
       example = [ "$HOME/.vscode-server" "$HOME/.vscode-server-oss" "$HOME/.vscode-server-insiders" ];
       description = ''
-        The install paths for VS Code Server.
+        Path(s) where VS Code Server will be installed.
+        Accepts either a single path string or a list of paths.
+        String values are automatically coerced to a single-element list for backwards compatibility.
       '';
     };
 

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -33,11 +33,11 @@ moduleConfig: {
     };
 
     installPath = mkOption {
-      type = str;
-      default = "$HOME/.vscode-server";
-      example = "$HOME/.vscode-server-oss";
+      type = listOf str;
+      default = [ "$HOME/.vscode-server" ];
+      example = [ "$HOME/.vscode-server" "$HOME/.vscode-server-oss" "$HOME/.vscode-server-insiders" ];
       description = ''
-        The install path.
+        The install paths for VS Code Server.
       '';
     };
 

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -71,7 +71,7 @@ moduleConfig: {
           # Unfortunately the monitor does not kill itself when it stops monitoring,
           # so rather than creating our own restart mechanism, we leverage systemd to do this for us.
           Restart = "always";
-          RestartSec = 0;
+          RestartSec = 5;
           ExecStart = "${auto-fix-vscode-server}/bin/auto-fix-vscode-server";
         };
       })

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -21,7 +21,7 @@
   enableFHS ? false,
   nodejsPackage ? null,
   extraRuntimeDependencies ? [ ],
-  installPath ? "$HOME/.vscode-server",
+  installPath ? [ "$HOME/.vscode-server" ],
   postPatch ? "",
 }: let
   inherit (lib) makeBinPath makeLibraryPath optionalString;


### PR DESCRIPTION
Currently, we can only set one installPath, but what if we use vscode, vscode-insiders, cursor simultaneously? So, this pr add the support for specifying multiple install path.