### PR TITLE
Fix: rename buildFHSUserEnv to buildFHSEnv to follow nixpkgs updates

### DIFF
--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -1,7 +1,6 @@
 {
   lib,
-  buildFHSUserEnv ? buildFHSEnv,
-  buildFHSEnv ? buildFHSUserEnv,
+  buildFHSEnv,
   runtimeShell,
   writeShellScript,
   writeShellApplication,
@@ -47,7 +46,7 @@
     ++ extraRuntimeDependencies;
 
   nodejs = nodejsPackage;
-  nodejsFHS = buildFHSUserEnv {
+  nodejsFHS = buildFHSEnv {
     name = "node";
     targetPkgs = _: runtimeDependencies;
     extraBuildCommands = ''


### PR DESCRIPTION
fix #95
Since the latest nixos-unstable bump, we get this error:
`error: 'buildFHSUserEnv' has been renamed to 'buildFHSEnv' and was removed in 25.11`